### PR TITLE
Change datatype of sildeShowDelay to double

### DIFF
--- a/Phototonic.cpp
+++ b/Phototonic.cpp
@@ -811,7 +811,7 @@ void Phototonic::createActions() {
     connect(resetZoomAction, &QAction::triggered, this, [=](){
         imageViewer->zoomTo(imageViewer->zoomMode() == ImageViewer::ZoomToFit ?
                                                                     ImageViewer::ZoomToFill :
-                                                                    ImageViewer::ZoomToFit); 
+                                                                    ImageViewer::ZoomToFit);
     });
 
     MAKE_ACTION(origZoomAction, tr("Original Size"), "origZoom", "/");
@@ -1895,7 +1895,7 @@ void Phototonic::batchTransform() {
                 MessageBox msgBox(this);
                 msgBox.critical(tr("Error"), tr("Failed to copy or move image."));
                 return;
-            } 
+            }
         }
     }
 
@@ -3084,7 +3084,7 @@ void Phototonic::reloadThumbs() {
     m_imageTags->removeTransientTags();
 
     if (findDupesAction->isChecked()) {
-        const bool actionEnabled[5] = { goBackAction->isEnabled(), goFrwdAction->isEnabled(), 
+        const bool actionEnabled[5] = { goBackAction->isEnabled(), goFrwdAction->isEnabled(),
                                         goUpAction->isEnabled(), goHomeAction->isEnabled(), refreshAction->isEnabled() };
         goBackAction->setEnabled(false);
         goFrwdAction->setEnabled(false);
@@ -3426,7 +3426,7 @@ bool Phototonic::eventFilter(QObject *o, QEvent *e)
                 animator->setEasingCurve(QEasingCurve::InOutQuad);
             }
             const int grid = thumbsViewer->gridSize().height();
-            int v = (animator->state() == QAbstractAnimation::Running) ? animator->endValue().toInt() : 
+            int v = (animator->state() == QAbstractAnimation::Running) ? animator->endValue().toInt() :
                                                                          thumbsViewer->verticalScrollBar()->value();
             animator->setStartValue(v);
             if (qAbs(steps) == 1000) {

--- a/Phototonic.cpp
+++ b/Phototonic.cpp
@@ -2445,7 +2445,7 @@ void Phototonic::readSettings() {
     Settings::showHiddenFiles = Settings::value(Settings::optionShowHiddenFiles, false).toBool();
     Settings::wrapImageList = Settings::value(Settings::optionWrapImageList, false).toBool();
     Settings::defaultSaveQuality = Settings::value(Settings::optionDefaultSaveQuality, 90).toInt();
-    Settings::slideShowDelay = Settings::value(Settings::optionSlideShowDelay, 5).toInt();
+    Settings::slideShowDelay = Settings::value(Settings::optionSlideShowDelay, 5.0).toDouble();
     Settings::slideShowRandom = Settings::value(Settings::optionSlideShowRandom, false).toBool();
     Settings::showImageName = Settings::value(Settings::optionShowImageName, false).toBool();
     Settings::smallToolbarIcons = Settings::value(Settings::optionSmallToolbarIcons, true).toBool();
@@ -2745,7 +2745,7 @@ void Phototonic::toggleSlideShow() {
 
         SlideShowTimer = new QTimer(this);
         connect(SlideShowTimer, SIGNAL(timeout()), this, SLOT(slideShowHandler()));
-        SlideShowTimer->start(Settings::slideShowDelay * 1000);
+        SlideShowTimer->start(Settings::slideShowDelay * 1000.0);
 
         slideShowAction->setText(tr("Stop Slide Show"));
         imageViewer->setFeedback(tr("Slide show started"));

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -82,7 +82,7 @@ namespace Settings {
     bool flipH;
     bool flipV;
     int defaultSaveQuality;
-    int slideShowDelay;
+    double slideShowDelay;
     bool slideShowRandom;
     bool slideShowActive;
     QMap<QString, QAction *> actionKeys;

--- a/Settings.h
+++ b/Settings.h
@@ -101,7 +101,7 @@ namespace Settings {
     extern bool flipH;
     extern bool flipV;
     extern int defaultSaveQuality;
-    extern int slideShowDelay;
+    extern double slideShowDelay;
     extern bool slideShowRandom;
     extern bool slideShowActive;
     extern QMap<QString, QAction *> actionKeys;

--- a/SettingsDialog.cpp
+++ b/SettingsDialog.cpp
@@ -19,6 +19,7 @@
 #include <QBoxLayout>
 #include <QCheckBox>
 #include <QColorDialog>
+#include <QDoubleSpinBox>
 #include <QFileDialog>
 #include <QGroupBox>
 #include <QHeaderView>
@@ -246,8 +247,8 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent) {
 
     // Slide show delay
     QLabel *slideDelayLab = new QLabel(tr("Delay between slides in seconds:"));
-    slideDelaySpinBox = new QSpinBox;
-    slideDelaySpinBox->setRange(1, 3600);
+    slideDelaySpinBox = new QDoubleSpinBox;
+    slideDelaySpinBox->setRange(0.1, 3600.0);
     slideDelaySpinBox->setValue(Settings::slideShowDelay);
     QHBoxLayout *slideDelayLayout = new QHBoxLayout;
     slideDelayLayout->addWidget(slideDelayLab);

--- a/SettingsDialog.h
+++ b/SettingsDialog.h
@@ -26,6 +26,7 @@ class QRadioButton;
 class QSpinBox;
 class QTableWidget;
 class QToolButton;
+class QDoubleSpinBox;
 #include <QDialog>
 
 class SettingsDialog : public QDialog {
@@ -69,7 +70,7 @@ private:
     QCheckBox *reverseMouseCheckBox;
     QCheckBox *scrollZoomCheckBox;
     QCheckBox *deleteConfirmCheckBox;
-    QSpinBox *slideDelaySpinBox;
+    QDoubleSpinBox *slideDelaySpinBox;
     QCheckBox *slideRandomCheckBox;
     QRadioButton *startupDirectoryRadioButtons[3];
     QLineEdit *startupDirLineEdit;


### PR DESCRIPTION
To be able to set sub second delays. QTimer::start uses milliseconds anyways.

Or is this for some reason a bad idea?