### PR TITLE
Fix slideshow wrap around

### DIFF
--- a/Phototonic.cpp
+++ b/Phototonic.cpp
@@ -2821,7 +2821,7 @@ void Phototonic::slideShowHandler() {
     }
 
     if (next < 0)
-        next = Settings::wrapImageList ? -1 : -2;
+        next = Settings::wrapImageList ? 0 : -2;
 
     if (next > -1 && next < thumbsViewer->model()->rowCount())
         QTimer::singleShot(500, this, [=]() {imageViewer->preload(thumbsViewer->fullPathOf(next));});

--- a/Phototonic.cpp
+++ b/Phototonic.cpp
@@ -811,7 +811,7 @@ void Phototonic::createActions() {
     connect(resetZoomAction, &QAction::triggered, this, [=](){
         imageViewer->zoomTo(imageViewer->zoomMode() == ImageViewer::ZoomToFit ?
                                                                     ImageViewer::ZoomToFill :
-                                                                    ImageViewer::ZoomToFit); 
+                                                                    ImageViewer::ZoomToFit);
     });
 
     MAKE_ACTION(origZoomAction, tr("Original Size"), "origZoom", "/");
@@ -1895,7 +1895,7 @@ void Phototonic::batchTransform() {
                 MessageBox msgBox(this);
                 msgBox.critical(tr("Error"), tr("Failed to copy or move image."));
                 return;
-            } 
+            }
         }
     }
 
@@ -3084,7 +3084,7 @@ void Phototonic::reloadThumbs() {
     m_imageTags->removeTransientTags();
 
     if (findDupesAction->isChecked()) {
-        const bool actionEnabled[5] = { goBackAction->isEnabled(), goFrwdAction->isEnabled(), 
+        const bool actionEnabled[5] = { goBackAction->isEnabled(), goFrwdAction->isEnabled(),
                                         goUpAction->isEnabled(), goHomeAction->isEnabled(), refreshAction->isEnabled() };
         goBackAction->setEnabled(false);
         goFrwdAction->setEnabled(false);
@@ -3426,7 +3426,7 @@ bool Phototonic::eventFilter(QObject *o, QEvent *e)
                 animator->setEasingCurve(QEasingCurve::InOutQuad);
             }
             const int grid = thumbsViewer->gridSize().height();
-            int v = (animator->state() == QAbstractAnimation::Running) ? animator->endValue().toInt() : 
+            int v = (animator->state() == QAbstractAnimation::Running) ? animator->endValue().toInt() :
                                                                          thumbsViewer->verticalScrollBar()->value();
             animator->setStartValue(v);
             if (qAbs(steps) == 1000) {


### PR DESCRIPTION
As far as I understand it the image index should be set to zero when the end of sequence is reached an  `wrapImageList` is active. Or am I missing/misunderstand something here?